### PR TITLE
Update schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ gem 'inquery'
 
 ```ruby
 class FetchUsersWithACar < Inquery::Query
-  schema(
-    color: :symbol
-  )
+  schema do
+    req :color, :symbol
+  end
 
   def call
     User.joins(:cars).where(cars: { color: osparams.color })
@@ -223,14 +223,12 @@ purpose, Inquery provides the `schema` method witch integrates the
 
 ```ruby
 class SomeQueryClass < Inquery::Query
-  schema(
-    some_param: :integer,
-    some_other_param: {
-      hash: {
-        some_field: :string
-      }
-    }
-  )
+  schema do
+    req :some_param, :integer
+    opt :some_other_param, :hash do
+      req :some_field, :string
+    end
+  end
 
   # ...
 end

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ task :gemspec do
     spec.add_dependency 'minitest'
     spec.add_dependency 'activesupport'
     spec.add_dependency 'activerecord'
-    spec.add_dependency 'schemacop', '~> 1'
+    spec.add_dependency 'schemacop', '~> 2'
   end
 
   File.open('inquery.gemspec', 'w') { |f| f.write(gemspec.to_ruby.strip) }

--- a/inquery.gemspec
+++ b/inquery.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<minitest>.freeze, [">= 0"])
       s.add_runtime_dependency(%q<activesupport>.freeze, [">= 0"])
       s.add_runtime_dependency(%q<activerecord>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<schemacop>.freeze, ["~> 1"])
+      s.add_runtime_dependency(%q<schemacop>.freeze, ["~> 2"])
     else
       s.add_dependency(%q<bundler>.freeze, ["~> 1.3"])
       s.add_dependency(%q<rake>.freeze, [">= 0"])
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<minitest>.freeze, [">= 0"])
       s.add_dependency(%q<activesupport>.freeze, [">= 0"])
       s.add_dependency(%q<activerecord>.freeze, [">= 0"])
-      s.add_dependency(%q<schemacop>.freeze, ["~> 1"])
+      s.add_dependency(%q<schemacop>.freeze, ["~> 2"])
     end
   else
     s.add_dependency(%q<bundler>.freeze, ["~> 1.3"])
@@ -53,6 +53,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<minitest>.freeze, [">= 0"])
     s.add_dependency(%q<activesupport>.freeze, [">= 0"])
     s.add_dependency(%q<activerecord>.freeze, [">= 0"])
-    s.add_dependency(%q<schemacop>.freeze, ["~> 1"])
+    s.add_dependency(%q<schemacop>.freeze, ["~> 2"])
   end
 end

--- a/lib/inquery/mixins/relation_validation.rb
+++ b/lib/inquery/mixins/relation_validation.rb
@@ -3,14 +3,12 @@ module Inquery
     module RelationValidation
       extend ActiveSupport::Concern
 
-      OPTIONS_SCHEMA = {
-        hash: {
-          class: { type: String, null: true, required: false },
-          fields: { type: :integer, null: true, required: false },
-          default_select: { type: :symbol, null: true, required: false },
-          default: { type: [Proc, FalseClass], null: true, required: false }
-        }
-      }
+      OPTIONS_SCHEMA = Schemacop::Schema.new do
+        opt :class, :string
+        opt :fields, :integer
+        opt :default_select, :symbol
+        opt :default, :object, classes: [Proc, FalseClass]
+      end
 
       DEFAULT_OPTIONS = {
         # Allows to restrict the class (attribute `klass`) of the relation. Use
@@ -46,7 +44,7 @@ module Inquery
         # Allows to configure the parameters of the relation this query operates
         # on. See {OPTIONS_SCHEMA} for documentation of the options hash.
         def relation(options = {})
-          Schemacop.validate!(OPTIONS_SCHEMA, options)
+          OPTIONS_SCHEMA.validate!(options)
           self._relation_options = options
         end
       end

--- a/lib/inquery/mixins/schema_validation.rb
+++ b/lib/inquery/mixins/schema_validation.rb
@@ -9,15 +9,8 @@ module Inquery
       end
 
       module ClassMethods
-        def schema(schema)
-          fail 'Schema must be a hash.' unless schema.is_a?(Hash)
-
-          unless schema[:type]
-            schema = {
-              type: :hash,
-              hash: schema
-            }
-          end
+        def schema(*args, &block)
+          schema = Schemacop::Schema.new(*args, &block)
 
           self._schema = schema
         end

--- a/lib/inquery/query.rb
+++ b/lib/inquery/query.rb
@@ -22,7 +22,7 @@ module Inquery
       @params = params
 
       if self.class._schema
-        Schemacop.validate!(self.class._schema, @params)
+        self.class._schema.validate!(@params)
       end
     end
 

--- a/test/inquery/query/chainable_test.rb
+++ b/test/inquery/query/chainable_test.rb
@@ -5,7 +5,7 @@ require 'queries/group/filter_with_color'
 
 module Inquery
   class Query
-    class ChainableTest < Minitest::Unit::TestCase
+    class ChainableTest < Minitest::Test
       include TestHelper
 
       def setup

--- a/test/inquery/query_test.rb
+++ b/test/inquery/query_test.rb
@@ -4,7 +4,7 @@ require 'queries/user/fetch_in_group'
 require 'queries/group/fetch_as_json'
 
 module Inquery
-  class QueryTest < Minitest::Unit::TestCase
+  class QueryTest < Minitest::Test
     include TestHelper
 
     def setup

--- a/test/inquery/query_test.rb
+++ b/test/inquery/query_test.rb
@@ -29,7 +29,7 @@ module Inquery
     end
 
     def test_fetch_users_in_group_with_invalid_schema
-      assert_raises Schemacop::Exceptions::Validation do
+      assert_raises Schemacop::Exceptions::ValidationError do
         Queries::User::FetchInGroup.run
       end
     end

--- a/test/queries/group/filter_with_color.rb
+++ b/test/queries/group/filter_with_color.rb
@@ -2,7 +2,9 @@ module Queries
   module Group
     class FilterWithColor < Inquery::Query::Chainable
       relation class: 'Group'
-      schema color: :string
+      schema do
+        req :color, :string
+      end
 
       def call
         relation.where(color: osparams.color)

--- a/test/queries/user/fetch_in_group.rb
+++ b/test/queries/user/fetch_in_group.rb
@@ -1,9 +1,9 @@
 module Queries
   module User
     class FetchInGroup < Inquery::Query
-      schema(
-        group_id: :integer
-      )
+      schema do
+        req :group_id, :integer
+      end
 
       def call
         ::Group.find(osparams.group_id).users


### PR DESCRIPTION
Use the new Schemacop (version 2) instead of the old.