### PR TITLE
Correct usage of the pessimistic version operator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ task :gemspec do
     spec.add_dependency 'minitest'
     spec.add_dependency 'activesupport'
     spec.add_dependency 'activerecord'
-    spec.add_dependency 'schemacop', '~> 2'
+    spec.add_dependency 'schemacop', '~> 2.0'
   end
 
   File.open('inquery.gemspec', 'w') { |f| f.write(gemspec.to_ruby.strip) }


### PR DESCRIPTION
Currently the dependency resolver of bundler cannot work because of faulty usage with the version operator.