### PR TITLE
Overwrite params with casted versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## UNRELEASED
+
+- Overwrite parameter hash with the casted version if using 
+  casting inside the schemacop `schema` block
+
 ## 1.0.2 (2019-10-09)
 
 - Add new mixin `RawSqlUtils`, which provides two methods for

--- a/lib/inquery/query.rb
+++ b/lib/inquery/query.rb
@@ -22,8 +22,8 @@ module Inquery
     def initialize(params = {})
       @params = params
 
-      if self.class._schema
-        self.class._schema.validate!(@params)
+      if _schema
+        @params = _schema.validate!(@params)
       end
     end
 


### PR DESCRIPTION
Schemacop casts the params in the schema to a specific format, however, the original params are not overwritten.
Change this behaviour such that the params hash includes the casted version of the original param.